### PR TITLE
fix: avoid OOM and infinite loops in moduleInfo.load()

### DIFF
--- a/.github/workflows/release-fork.yaml
+++ b/.github/workflows/release-fork.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           release-type: simple
           default-branch: release-fork
-          release-as: 0.27.0-pre.1
+          release-as: 0.28.0-pre.1
           changelog-types: ${{ steps.configure-changelog.outputs.result }}
           # https://github.com/google-github-actions/release-please-action#github-credentials
           token: ${{ secrets.VINCENT_PAT }}

--- a/server/events/mocks/mock_command_requirement_handler.go
+++ b/server/events/mocks/mock_command_requirement_handler.go
@@ -44,25 +44,6 @@ func (mock *MockCommandRequirementHandler) ValidateApplyProject(repoDir string, 
 	return ret0, ret1
 }
 
-func (mock *MockCommandRequirementHandler) ValidateProjectDependencies(_param0 command.ProjectContext) (string, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCommandRequirementHandler().")
-	}
-	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("ValidateProjectDependencies", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 string
-	var ret1 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-		if result[1] != nil {
-			ret1 = result[1].(error)
-		}
-	}
-	return ret0, ret1
-}
-
 func (mock *MockCommandRequirementHandler) ValidateImportProject(repoDir string, ctx command.ProjectContext) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommandRequirementHandler().")
@@ -88,6 +69,25 @@ func (mock *MockCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 	}
 	params := []pegomock.Param{repoDir, ctx}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("ValidatePlanProject", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
+func (mock *MockCommandRequirementHandler) ValidateProjectDependencies(ctx command.ProjectContext) (string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockCommandRequirementHandler().")
+	}
+	params := []pegomock.Param{ctx}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("ValidateProjectDependencies", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
 	var ret1 error
 	if len(result) != 0 {
@@ -142,25 +142,6 @@ func (verifier *VerifierMockCommandRequirementHandler) ValidateApplyProject(repo
 	params := []pegomock.Param{repoDir, ctx}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ValidateApplyProject", params, verifier.timeout)
 	return &MockCommandRequirementHandler_ValidateApplyProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-func (mock *MockCommandRequirementHandler) ValidateProjectDependencies(_param0 command.ProjectContext) (string, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCommandRequirementHandler().")
-	}
-	params := []pegomock.Param{_param0}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("ValidateProjectDependencies", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 string
-	var ret1 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-		if result[1] != nil {
-			ret1 = result[1].(error)
-		}
-	}
-	return ret0, ret1
 }
 
 type MockCommandRequirementHandler_ValidateApplyProject_OngoingVerification struct {
@@ -245,6 +226,33 @@ func (c *MockCommandRequirementHandler_ValidatePlanProject_OngoingVerification) 
 		_param1 = make([]command.ProjectContext, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(command.ProjectContext)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockCommandRequirementHandler) ValidateProjectDependencies(ctx command.ProjectContext) *MockCommandRequirementHandler_ValidateProjectDependencies_OngoingVerification {
+	params := []pegomock.Param{ctx}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ValidateProjectDependencies", params, verifier.timeout)
+	return &MockCommandRequirementHandler_ValidateProjectDependencies_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockCommandRequirementHandler_ValidateProjectDependencies_OngoingVerification struct {
+	mock              *MockCommandRequirementHandler
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockCommandRequirementHandler_ValidateProjectDependencies_OngoingVerification) GetCapturedArguments() command.ProjectContext {
+	ctx := c.GetAllCapturedArguments()
+	return ctx[len(ctx)-1]
+}
+
+func (c *MockCommandRequirementHandler_ValidateProjectDependencies_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]command.ProjectContext, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(command.ProjectContext)
 		}
 	}
 	return


### PR DESCRIPTION
cherry pick
https://github.com/runatlantis/atlantis/pull/3769

moduleInfo.load() used to load modules and depdencies recursively,
and due to some unfortunate circumstances it would usually create a
very deep call stack where each load() called another load() to load
the next one.

The terraform parsing uses enough stack space that this can become a
problem, so for a slightly big project this sometimes caused atlantis
to die from a stack overflow:

runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc021478380 stack=[0xc021478000, 0xc041478000]
fatal error: stack overflow
[...]
github.com/runatlantis/atlantis/server/events.moduleInfo.load(...)
	...atlantis/server/events/modules.go:108 +0x46b fp=0xc021478750 sp=0xc021478570 pc=0xfeaa6b
github.com/runatlantis/atlantis/server/events.moduleInfo.load(...)
	...atlantis/server/events/modules.go:108 +0x46b fp=0xc021478930 sp=0xc021478750 pc=0xfeaa6b
github.com/runatlantis/atlantis/server/events.moduleInfo.load(...)
	...atlantis/server/events/modules.go:108 +0x46b fp=0xc021478b10 sp=0xc021478930 pc=0xfeaa6b

... and so on, several hundred times.
